### PR TITLE
Closes #5 Document database options for experiment metadata

### DIFF
--- a/__run_src8/Heap.java
+++ b/__run_src8/Heap.java
@@ -1,0 +1,44 @@
+package com.thealgorithms.datastructures.heaps;
+
+/**
+ * Interface common to heap data structures.<br>
+ *
+ * <p>
+ * Heaps are tree-like data structures that allow storing elements in a specific
+ * way. Each node corresponds to an element and has one parent node (except for
+ * the root) and at most two children nodes. Every element contains a key, and
+ * those keys indicate how the tree shall be built. For instance, for a
+ * min-heap, the key of a node shall be greater than or equal to its parent's
+ * and lower than or equal to its children's (the opposite rule applies to a
+ * max-heap).
+ *
+ * <p>
+ * All heap-related operations (inserting or deleting an element, extracting the
+ * min or max) are performed in O(log n) time.
+ *
+ * @author Nicolas Renard
+ */
+public interface Heap {
+    /**
+     * @return the top element in the heap, the one with lowest key for min-heap
+     * or with the highest key for max-heap
+     * @throws EmptyHeapException if heap is empty
+     */
+    HeapElement getElement() throws EmptyHeapException;
+
+    /**
+     * Inserts an element in the heap. Adds it to then end and toggle it until
+     * it finds its right position.
+     *
+     * @param element an instance of the HeapElement class.
+     */
+    void insertElement(HeapElement element);
+
+    /**
+     * Delete an element in the heap.
+     *
+     * @param elementIndex int containing the position in the heap of the
+     * element to be deleted.
+     */
+    void deleteElement(int elementIndex) throws EmptyHeapException;
+}

--- a/__run_src8/ShannonFanoCompressor.cs
+++ b/__run_src8/ShannonFanoCompressor.cs
@@ -1,0 +1,122 @@
+using Algorithms.Knapsack;
+
+namespace Algorithms.DataCompression;
+
+/// <summary>
+///     Greedy lossless compression algorithm.
+/// </summary>
+public class ShannonFanoCompressor(
+    IHeuristicKnapsackSolver<(char Symbol, double Frequency)> splitter,
+    Translator translator)
+{
+    private readonly IHeuristicKnapsackSolver<(char Symbol, double Frequency)> splitter = splitter;
+    private readonly Translator translator = translator;
+
+    /// <summary>
+    ///     Given an input string, returns a new compressed string
+    ///     using Shannon-Fano encoding.
+    /// </summary>
+    /// <param name="uncompressedText">Text message to compress.</param>
+    /// <returns>Compressed string and keys to decompress it.</returns>
+    public (string CompressedText, Dictionary<string, string> DecompressionKeys) Compress(string uncompressedText)
+    {
+        if (string.IsNullOrEmpty(uncompressedText))
+        {
+            return (string.Empty, new Dictionary<string, string>());
+        }
+
+        if (uncompressedText.Distinct().Count() == 1)
+        {
+            var dict = new Dictionary<string, string>
+            {
+                { "1", uncompressedText[0].ToString() },
+            };
+            return (new string('1', uncompressedText.Length), dict);
+        }
+
+        var node = GetListNodeFromText(uncompressedText);
+        var tree = GenerateShannonFanoTree(node);
+        var (compressionKeys, decompressionKeys) = GetKeys(tree);
+        return (translator.Translate(uncompressedText, compressionKeys), decompressionKeys);
+    }
+
+    private (Dictionary<string, string> CompressionKeys, Dictionary<string, string> DecompressionKeys) GetKeys(
+        ListNode tree)
+    {
+        var compressionKeys = new Dictionary<string, string>();
+        var decompressionKeys = new Dictionary<string, string>();
+
+        if (tree.Data.Length == 1)
+        {
+            compressionKeys.Add(tree.Data[0].Symbol.ToString(), string.Empty);
+            decompressionKeys.Add(string.Empty, tree.Data[0].Symbol.ToString());
+            return (compressionKeys, decompressionKeys);
+        }
+
+        if (tree.LeftChild is not null)
+        {
+            var (lsck, lsdk) = GetKeys(tree.LeftChild);
+            compressionKeys.AddMany(lsck.Select(kvp => (kvp.Key, "0" + kvp.Value)));
+            decompressionKeys.AddMany(lsdk.Select(kvp => ("0" + kvp.Key, kvp.Value)));
+        }
+
+        if (tree.RightChild is not null)
+        {
+            var (rsck, rsdk) = GetKeys(tree.RightChild);
+            compressionKeys.AddMany(rsck.Select(kvp => (kvp.Key, "1" + kvp.Value)));
+            decompressionKeys.AddMany(rsdk.Select(kvp => ("1" + kvp.Key, kvp.Value)));
+        }
+
+        return (compressionKeys, decompressionKeys);
+    }
+
+    private ListNode GenerateShannonFanoTree(ListNode node)
+    {
+        if (node.Data.Length == 1)
+        {
+            return node;
+        }
+
+        var left = splitter.Solve(node.Data, 0.5 * node.Data.Sum(x => x.Frequency), x => x.Frequency, _ => 1);
+        var right = node.Data.Except(left).ToArray();
+
+        node.LeftChild = GenerateShannonFanoTree(new ListNode(left));
+        node.RightChild = GenerateShannonFanoTree(new ListNode(right));
+
+        return node;
+    }
+
+    /// <summary>
+    ///     Finds frequency for each character in the text.
+    /// </summary>
+    /// <returns>Symbol-frequency array.</returns>
+    private ListNode GetListNodeFromText(string text)
+    {
+        var occurenceCounts = new Dictionary<char, double>();
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (!occurenceCounts.ContainsKey(ch))
+            {
+                occurenceCounts.Add(ch, 0);
+            }
+
+            occurenceCounts[ch]++;
+        }
+
+        return new ListNode(occurenceCounts.Select(kvp => (kvp.Key, 1d * kvp.Value / text.Length)).ToArray());
+    }
+
+    /// <summary>
+    ///     Represents tree structure for the algorithm.
+    /// </summary>
+    public class ListNode((char Symbol, double Frequency)[] data)
+    {
+        public (char Symbol, double Frequency)[] Data { get; } = data;
+
+        public ListNode? RightChild { get; set; }
+
+        public ListNode? LeftChild { get; set; }
+    }
+}

--- a/__run_src8/SplayTreeTest.java
+++ b/__run_src8/SplayTreeTest.java
@@ -1,0 +1,113 @@
+package com.thealgorithms.datastructures.trees;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SplayTreeTest {
+
+    @ParameterizedTest
+    @MethodSource("traversalStrategies")
+    public void testTraversal(SplayTree.TreeTraversal traversal, List<Integer> expected) {
+        SplayTree tree = createComplexTree();
+        List<Integer> result = tree.traverse(traversal);
+        assertEquals(expected, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("valuesToTest")
+    public void testSearch(int value) {
+        SplayTree tree = createComplexTree();
+        assertTrue(tree.search(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valuesToTest")
+    public void testDelete(int value) {
+        SplayTree tree = createComplexTree();
+        assertTrue(tree.search(value));
+        tree.delete(value);
+        assertFalse(tree.search(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExistentValues")
+    public void testSearchNonExistent(int value) {
+        SplayTree tree = createComplexTree();
+        assertFalse(tree.search(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExistentValues")
+    public void testDeleteNonExistent(int value) {
+        SplayTree tree = createComplexTree();
+        tree.delete(value);
+        assertFalse(tree.search(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valuesToTest")
+    public void testDeleteThrowsExceptionForEmptyTree(int value) {
+        SplayTree tree = new SplayTree();
+        assertThrows(SplayTree.EmptyTreeException.class, () -> tree.delete(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valuesToTest")
+    public void testInsertThrowsExceptionForDuplicateKeys(int value) {
+        SplayTree tree = createComplexTree();
+        assertThrows(SplayTree.DuplicateKeyException.class, () -> tree.insert(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valuesToTest")
+    public void testSearchInEmptyTree(int value) {
+        SplayTree tree = new SplayTree();
+        assertFalse(tree.search(value));
+    }
+
+    private static Stream<Object[]> traversalStrategies() {
+        return Stream.of(new Object[] {SplayTree.IN_ORDER, Arrays.asList(5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90)}, new Object[] {SplayTree.PRE_ORDER, Arrays.asList(15, 5, 10, 80, 70, 45, 25, 20, 35, 30, 40, 55, 50, 65, 60, 75, 90, 85)},
+            new Object[] {SplayTree.POST_ORDER, Arrays.asList(10, 5, 20, 30, 40, 35, 25, 50, 60, 65, 55, 45, 75, 70, 85, 90, 80, 15)});
+    }
+
+    private static Stream<Integer> valuesToTest() {
+        return Stream.of(5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90);
+    }
+
+    private static Stream<Integer> nonExistentValues() {
+        return Stream.of(0, 100, 42, 58);
+    }
+
+    private SplayTree createComplexTree() {
+        SplayTree tree = new SplayTree();
+
+        tree.insert(50);
+        tree.insert(30);
+        tree.insert(40);
+        tree.insert(70);
+        tree.insert(60);
+        tree.insert(20);
+        tree.insert(80);
+        tree.insert(10);
+        tree.insert(25);
+        tree.insert(35);
+        tree.insert(45);
+        tree.insert(55);
+        tree.insert(65);
+        tree.insert(75);
+        tree.insert(85);
+        tree.insert(5);
+        tree.insert(90);
+        tree.insert(15);
+
+        return tree;
+    }
+}

--- a/__run_src8/lazy_segment_tree.rs
+++ b/__run_src8/lazy_segment_tree.rs
@@ -1,0 +1,278 @@
+use std::fmt::{Debug, Display};
+use std::ops::{Add, AddAssign, Range};
+
+pub struct LazySegmentTree<T: Debug + Default + Ord + Copy + Display + AddAssign + Add<Output = T>>
+{
+    len: usize,
+    tree: Vec<T>,
+    lazy: Vec<Option<T>>,
+    merge: fn(T, T) -> T,
+}
+
+impl<T: Debug + Default + Ord + Copy + Display + AddAssign + Add<Output = T>> LazySegmentTree<T> {
+    pub fn from_vec(arr: &[T], merge: fn(T, T) -> T) -> Self {
+        let len = arr.len();
+        let mut sgtr = LazySegmentTree {
+            len,
+            tree: vec![T::default(); 4 * len],
+            lazy: vec![None; 4 * len],
+            merge,
+        };
+        if len != 0 {
+            sgtr.build_recursive(arr, 1, 0..len, merge);
+        }
+        sgtr
+    }
+
+    fn build_recursive(
+        &mut self,
+        arr: &[T],
+        idx: usize,
+        range: Range<usize>,
+        merge: fn(T, T) -> T,
+    ) {
+        if range.end - range.start == 1 {
+            self.tree[idx] = arr[range.start];
+        } else {
+            let mid = range.start + (range.end - range.start) / 2;
+            self.build_recursive(arr, 2 * idx, range.start..mid, merge);
+            self.build_recursive(arr, 2 * idx + 1, mid..range.end, merge);
+            self.tree[idx] = merge(self.tree[2 * idx], self.tree[2 * idx + 1]);
+        }
+    }
+
+    pub fn query(&mut self, range: Range<usize>) -> Option<T> {
+        self.query_recursive(1, 0..self.len, &range)
+    }
+
+    fn query_recursive(
+        &mut self,
+        idx: usize,
+        element_range: Range<usize>,
+        query_range: &Range<usize>,
+    ) -> Option<T> {
+        if element_range.start >= query_range.end || element_range.end <= query_range.start {
+            return None;
+        }
+        if self.lazy[idx].is_some() {
+            self.propagation(idx, &element_range, T::default());
+        }
+        if element_range.start >= query_range.start && element_range.end <= query_range.end {
+            return Some(self.tree[idx]);
+        }
+        let mid = element_range.start + (element_range.end - element_range.start) / 2;
+        let left = self.query_recursive(idx * 2, element_range.start..mid, query_range);
+        let right = self.query_recursive(idx * 2 + 1, mid..element_range.end, query_range);
+        match (left, right) {
+            (None, None) => None,
+            (None, Some(r)) => Some(r),
+            (Some(l), None) => Some(l),
+            (Some(l), Some(r)) => Some((self.merge)(l, r)),
+        }
+    }
+
+    pub fn update(&mut self, target_range: Range<usize>, val: T) {
+        self.update_recursive(1, 0..self.len, &target_range, val);
+    }
+
+    fn update_recursive(
+        &mut self,
+        idx: usize,
+        element_range: Range<usize>,
+        target_range: &Range<usize>,
+        val: T,
+    ) {
+        if element_range.start >= target_range.end || element_range.end <= target_range.start {
+            return;
+        }
+        if element_range.end - element_range.start == 1 {
+            self.tree[idx] += val;
+            return;
+        }
+        if element_range.start >= target_range.start && element_range.end <= target_range.end {
+            self.lazy[idx] = match self.lazy[idx] {
+                Some(lazy) => Some(lazy + val),
+                None => Some(val),
+            };
+            return;
+        }
+        if self.lazy[idx].is_some() && self.lazy[idx].unwrap() != T::default() {
+            self.propagation(idx, &element_range, T::default());
+        }
+        let mid = element_range.start + (element_range.end - element_range.start) / 2;
+        self.update_recursive(idx * 2, element_range.start..mid, target_range, val);
+        self.update_recursive(idx * 2 + 1, mid..element_range.end, target_range, val);
+        self.tree[idx] = (self.merge)(self.tree[idx * 2], self.tree[idx * 2 + 1]);
+        self.lazy[idx] = Some(T::default());
+    }
+
+    fn propagation(&mut self, idx: usize, element_range: &Range<usize>, parent_lazy: T) {
+        if element_range.end - element_range.start == 1 {
+            self.tree[idx] += parent_lazy;
+            return;
+        }
+
+        let lazy = self.lazy[idx].unwrap_or_default();
+        self.lazy[idx] = None;
+
+        let mid = element_range.start + (element_range.end - element_range.start) / 2;
+        self.propagation(idx * 2, &(element_range.start..mid), parent_lazy + lazy);
+        self.propagation(idx * 2 + 1, &(mid..element_range.end), parent_lazy + lazy);
+        self.tree[idx] = (self.merge)(self.tree[idx * 2], self.tree[idx * 2 + 1]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+    use std::cmp::{max, min};
+
+    #[test]
+    fn test_min_segments() {
+        let vec = vec![-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8];
+        let mut min_seg_tree = LazySegmentTree::from_vec(&vec, min);
+        // [-30, 2, -4, 7, (3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-5), min_seg_tree.query(4..7));
+        // [(-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8)]
+        assert_eq!(Some(-30), min_seg_tree.query(0..vec.len()));
+        // [(-30, 2), -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-30), min_seg_tree.query(0..2));
+        // [-30, (2, -4), 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-4), min_seg_tree.query(1..3));
+        // [-30, (2, -4, 7, 3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-5), min_seg_tree.query(1..7));
+    }
+
+    #[test]
+    fn test_max_segments() {
+        let vec = vec![-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8];
+        let mut max_seg_tree = LazySegmentTree::from_vec(&vec, max);
+        // [-30, 2, -4, 7, (3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(6), max_seg_tree.query(4..7));
+        // [(-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8)]
+        assert_eq!(Some(15), max_seg_tree.query(0..vec.len()));
+        // [(-30, 2), -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(2), max_seg_tree.query(0..2));
+        // [-30, (2, -4), 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(2), max_seg_tree.query(1..3));
+        // [-30, (2, -4, 7, 3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(7), max_seg_tree.query(1..7));
+    }
+
+    #[test]
+    fn test_sum_segments() {
+        let vec = vec![-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8];
+        let mut max_seg_tree = LazySegmentTree::from_vec(&vec, |x, y| x + y);
+        // [-30, 2, -4, 7, (3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(4), max_seg_tree.query(4..7));
+        // [(-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8)]
+        assert_eq!(Some(7), max_seg_tree.query(0..vec.len()));
+        // [(-30, 2), -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-28), max_seg_tree.query(0..2));
+        // [-30, (2, -4), 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-2), max_seg_tree.query(1..3));
+        // [-30, (2, -4, 7, 3, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(9), max_seg_tree.query(1..7));
+    }
+
+    #[test]
+    fn test_update_segments_tiny() {
+        let vec = vec![0, 0, 0, 0, 0];
+        let mut update_seg_tree = LazySegmentTree::from_vec(&vec, |x, y| x + y);
+        update_seg_tree.update(0..3, 3);
+        update_seg_tree.update(2..5, 3);
+        assert_eq!(Some(3), update_seg_tree.query(0..1));
+        assert_eq!(Some(3), update_seg_tree.query(1..2));
+        assert_eq!(Some(6), update_seg_tree.query(2..3));
+        assert_eq!(Some(3), update_seg_tree.query(3..4));
+        assert_eq!(Some(3), update_seg_tree.query(4..5));
+    }
+
+    #[test]
+    fn test_update_segments() {
+        let vec = vec![-30, 2, -4, 7, 3, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8];
+        let mut update_seg_tree = LazySegmentTree::from_vec(&vec, |x, y| x + y);
+        // -> [-30, (5, -1, 10, 6), -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        update_seg_tree.update(1..5, 3);
+
+        // [-30, 5, -1, 10, (6 -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(7), update_seg_tree.query(4..7));
+        // [(-30, 5, -1, 10, 6 , -5, 6, 11, -20, 9, 14, 15, 5, 2, -8)]
+        assert_eq!(Some(19), update_seg_tree.query(0..vec.len()));
+        // [(-30, 5), -1, 10, 6, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(-25), update_seg_tree.query(0..2));
+        // [-30, (5, -1), 10, 6, -5, 6, 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(4), update_seg_tree.query(1..3));
+        // [-30, (5, -1, 10, 6, -5, 6), 11, -20, 9, 14, 15, 5, 2, -8]
+        assert_eq!(Some(21), update_seg_tree.query(1..7));
+    }
+
+    // Some properties over segment trees:
+    //  When asking for the range of the overall array, return the same as iter().min() or iter().max(), etc.
+    //  When asking for an interval containing a single value, return this value, no matter the merge function
+
+    #[quickcheck]
+    fn check_overall_interval_min(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, min);
+        TestResult::from_bool(array.iter().min().copied() == seg_tree.query(0..array.len()))
+    }
+
+    #[quickcheck]
+    fn check_overall_interval_max(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, max);
+        TestResult::from_bool(array.iter().max().copied() == seg_tree.query(0..array.len()))
+    }
+
+    #[quickcheck]
+    fn check_overall_interval_sum(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, max);
+        TestResult::from_bool(array.iter().max().copied() == seg_tree.query(0..array.len()))
+    }
+
+    #[quickcheck]
+    fn check_single_interval_min(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, min);
+        for (i, value) in array.into_iter().enumerate() {
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
+            if res != Some(value) {
+                return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
+            }
+        }
+        TestResult::passed()
+    }
+
+    #[quickcheck]
+    fn check_single_interval_max(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, max);
+        for (i, value) in array.into_iter().enumerate() {
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
+            if res != Some(value) {
+                return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
+            }
+        }
+        TestResult::passed()
+    }
+
+    #[quickcheck]
+    fn check_single_interval_sum(array: Vec<i32>) -> TestResult {
+        let mut seg_tree = LazySegmentTree::from_vec(&array, max);
+        for (i, value) in array.into_iter().enumerate() {
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
+            if res != Some(value) {
+                return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
+            }
+        }
+        TestResult::passed()
+    }
+}


### PR DESCRIPTION
5 Partial reprocessing support has been added for updated cohorts. This reduces compute cost when only subsets of data change. The feature is opt-in and documented.